### PR TITLE
Canary Base

### DIFF
--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
-add_library(citra_libretro SHARED
+add_library(citra_canary_libretro SHARED
         emu_window/libretro_window.cpp
         emu_window/libretro_window.h
         input/input_factory.cpp
@@ -16,10 +16,10 @@ add_library(citra_libretro SHARED
         libretro_logger.cpp
         libretro_logger.h)
 
-create_target_directory_groups(citra_libretro)
+create_target_directory_groups(citra_canary_libretro)
 
-target_link_libraries(citra_libretro PRIVATE common core)
-target_link_libraries(citra_libretro PRIVATE glad libretro)
-target_link_libraries(citra_libretro PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
+target_link_libraries(citra_canary_libretro PRIVATE common core)
+target_link_libraries(citra_canary_libretro PRIVATE glad libretro)
+target_link_libraries(citra_canary_libretro PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
-set_target_properties(citra_libretro PROPERTIES PREFIX "")
+set_target_properties(citra_canary_libretro PROPERTIES PREFIX "")

--- a/src/citra_libretro/environment.cpp
+++ b/src/citra_libretro/environment.cpp
@@ -128,7 +128,7 @@ int16_t CheckInput(unsigned port, unsigned device, unsigned index, unsigned id) 
 
 void retro_get_system_info(struct retro_system_info* info) {
     memset(info, 0, sizeof(*info));
-    info->library_name = "Citra";
+    info->library_name = "Citra Canary";
     info->library_version = Common::g_scm_desc;
     info->need_fullpath = true;
     info->valid_extensions = "3ds|3dsx|cia|elf";


### PR DESCRIPTION
DO NOT MERGE
==========

This renames the resulting .dll so that it can be differentiated in the buildbot. This is automatically merged into canary by the buildbot, so should not be merged manually.