### PR TITLE
add conditional for static linking libstdc++ for libretro

### DIFF
--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -21,5 +21,8 @@ create_target_directory_groups(citra_libretro)
 target_link_libraries(citra_libretro PRIVATE common core)
 target_link_libraries(citra_libretro PRIVATE glad libretro)
 target_link_libraries(citra_libretro PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
+if(DEFINED LIBRETRO_STATIC)
+target_link_libraries(citra_libretro PRIVATE -static-libstdc++)
+endif()
 
 set_target_properties(citra_libretro PROPERTIES PREFIX "")


### PR DESCRIPTION
this should allow the buildbot linux x64 cores to be compatible with snap et al "universal" packages and older distros without making a bloated binary unnecessarily. Closes #55 