### PR TITLE
Add option to disable mouse input for touchscreen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,78 +1,32 @@
-language: cpp
-matrix:
-  include:
-    - os: linux
-      env: NAME="clang-format"
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-6.0
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang-format-6.0
-      script: "./.travis/clang-format/script.sh"
-    - os: linux
-      env: NAME="linux build"
-      sudo: required
-      dist: trusty
-      services: docker
-      addons:
-        apt:
-          packages:
-            - p7zip-full
-      install: "./.travis/linux/deps.sh"
-      script: "./.travis/linux/build.sh"
-      after_success: "./.travis/linux/upload.sh"
-      cache: ccache
-    - if: repo = citra-emu/citra AND branch = master AND type = push
-      os: linux
-      env: NAME="transifex push"
-      sudo: required
-      dist: trusty
-      services: docker
-      install: "./.travis/transifex/deps.sh"
-      script: "./.travis/transifex/build.sh"
-    - os: osx
-      env: NAME="macos build"
-      sudo: false
-      osx_image: xcode10
-      install: "./.travis/macos/deps.sh"
-      script: "./.travis/macos/build.sh"
-      after_success: "./.travis/macos/upload.sh"
-      cache: ccache
-    - os: linux
-      env: NAME="linux build (frozen versions of dependencies)"
-      sudo: required
-      dist: trusty
-      services: docker
-      cache: ccache
-      script: "./.travis/linux-frozen/build.sh"
-    - os: linux
-      env: NAME="MinGW build"
-      sudo: required
-      dist: trusty
-      services: docker
-      addons:
-        apt:
-          packages:
-            - p7zip-full
-      install: "./.travis/linux-mingw/deps.sh"
-      script: "./.travis/linux-mingw/build.sh"
-      after_success: "./.travis/linux-mingw/upload.sh"
-      cache: ccache
-
-deploy:
-  provider: releases
-  api_key:
-    secure: Mck15DIWaJdxDiS3aYVlM9N3G6y8VKUI1rnwII7/iolfm1s94U+tgvbheZDmT7SSbFyaGaYO/E8HrV/uZR9Vvs7ev20sHsTN1u60OTWfDIIyHs9SqjhcGbtq95m9/dMFschOYqTOR+gAs5BsxjuoeAotHdhpQEwvkO2oo5oR0zhGy45gjFnVvtcxT/IfpZBIpVgcK3aLb9zT6ekcJbSiPmEB15iLq3xXd0nFUNtEZdX3D6Veye4n5jB6n72qN8JVoKvPZAwaC2K0pZxpcGJaXDchLsw1q+4eCvdz6UJfUemeQ/uMAmjfeQ3wrzYGXe3nCM3WmX5wosCsB0mw4zYatzl3si6CZ1W+0GkV4Rwlx03dfp7v3EeFhTsXYCaXqhwuLZnWOLUik8t9vaSoFUx4nUIRwfO9kAMUJQSpLuHNO2nT01s3GxvqxzczuLQ9he5nGSi0RRodUzDwek1qUp6I4uV3gRHKz4B07YIc1i2fK88NLXjyQ0uLVZ+7Oq1+kgDp6+N7vvXXZ5qZ17tdaysSbKEE0Y8zsoXw7Rk1tPN19vrCS+TSpomNMyQyne1k+I5iZ/qkxPTLAS5qI6Utc2dL3GJdxWRAEfGNO9AIX3GV/jmmKfdcvwGsCYP8hxqs5vLYfgacw3D8NLf1941lQUwavC17jm9EV9g5G3Pn1Cp516E=
-  file_glob: true
-  file: "artifacts/*"
-  skip_cleanup: true
-  on:
-    tags: true
-
-notifications:
-  webhooks:
-    urls:
-      - https://api.citra-emu.org/code/travis/notify
+language: generic
+os: linux
+dist: trusty
+sudo: required
+addons:
+  apt:
+    packages:
+      - g++-7
+    sources:
+      - ubuntu-toolchain-r-test
+env:
+  global:
+    - CORE=citra
+    - COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7
+  matrix:
+    - PLATFORM=linux_x64
+before_script:
+  - pwd
+  - mkdir -p ~/bin
+  - ln -s /usr/bin/gcc-7 ~/bin/gcc
+  - ln -s /usr/bin/g++-7 ~/bin/g++
+  - ln -s /usr/bin/cpp-7 ~/bin/cpp
+  - export PATH=~/bin:$PATH
+  - ls -l ~/bin
+  - echo $PATH
+  - g++-7 --version
+  - g++ --version
+script:
+  - cd ~/
+  - git clone --depth=50 https://github.com/libretro/libretro-super
+  - cd libretro-super/travis
+  - ./build.sh

--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -101,6 +101,7 @@ void LibRetro::OnConfigureEnvironment() {
         {"citra_analog_function",
          "Right analog function; C-Stick and Touchscreen Pointer|Touchscreen Pointer|C-Stick"},
         {"citra_deadzone", "Emulated pointer deadzone (%); 15|20|25|30|35|0|5|10"},
+        {"citra_mouse_touchscreen", "Enable mouse input for touchscreen; enabled|disabled"},
         {"citra_use_virtual_sd", "Enable virtual SD card; enabled|disabled"},
         {"citra_use_libretro_save_path", "Savegame location; LibRetro Default|Citra Default"},
         {"citra_is_new_3ds", "3DS system model; Old 3DS|New 3DS"},
@@ -184,6 +185,8 @@ void UpdateSettings() {
     Settings::values.swap_screen = LibRetro::FetchVariable("citra_swap_screen", "Top") == "Bottom";
     Settings::values.use_gdbstub =
         LibRetro::FetchVariable("citra_use_gdbstub", "disabled") == "enabled";
+    LibRetro::settings.mouse_touchscreen =
+        LibRetro::FetchVariable("citra_mouse_touchscreen", "enabled") == "enabled";
 
     // These values are a bit more hard to define, unfortunately.
     auto scaling = LibRetro::FetchVariable("citra_resolution_factor", "1x (Native)");

--- a/src/citra_libretro/core_settings.h
+++ b/src/citra_libretro/core_settings.h
@@ -15,6 +15,8 @@ struct CoreSettings {
     ::std::string file_path;
 
     float deadzone = 1.f;
+    
+    bool mouse_touchscreen;
 
     LibRetro::CStickFunction analog_function;
 

--- a/src/citra_libretro/core_settings.h
+++ b/src/citra_libretro/core_settings.h
@@ -15,10 +15,10 @@ struct CoreSettings {
     ::std::string file_path;
 
     float deadzone = 1.f;
-    
-    bool mouse_touchscreen;
 
     LibRetro::CStickFunction analog_function;
+
+    bool mouse_touchscreen;
 
 } extern settings;
 

--- a/src/citra_libretro/input/mouse_tracker.cpp
+++ b/src/citra_libretro/input/mouse_tracker.cpp
@@ -97,6 +97,7 @@ void MouseTracker::Update(int bufferWidth, int bufferHeight,
                          std::min(newY, static_cast<int>(bottomScreen.bottom))) -
                 bottomScreen.top;
         }
+    }
     if (LibRetro::settings.analog_function != LibRetro::CStickFunction::CStick) {
         // Check right analog input
         state |= LibRetro::CheckInput(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);

--- a/src/citra_libretro/input/mouse_tracker.cpp
+++ b/src/citra_libretro/input/mouse_tracker.cpp
@@ -97,7 +97,7 @@ void MouseTracker::Update(int bufferWidth, int bufferHeight,
                          std::min(newY, static_cast<int>(bottomScreen.bottom))) -
                 bottomScreen.top;
         }
-    } else if (LibRetro::settings.analog_function != LibRetro::CStickFunction::CStick) {
+    if (LibRetro::settings.analog_function != LibRetro::CStickFunction::CStick) {
         // Check right analog input
         state |= LibRetro::CheckInput(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
 

--- a/src/citra_libretro/input/mouse_tracker.cpp
+++ b/src/citra_libretro/input/mouse_tracker.cpp
@@ -73,33 +73,38 @@ void MouseTracker::Restrict(int minX, int minY, int maxX, int maxY) {
 
 void MouseTracker::Update(int bufferWidth, int bufferHeight,
                           MathUtil::Rectangle<unsigned> bottomScreen) {
-    // Check mouse input
-    bool state =
-        (bool)(LibRetro::CheckInput(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT)) ||
-        (bool)(LibRetro::CheckInput(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3));
+    bool state = false;
 
-    // TODO: Provide config option for ratios here
-    auto widthSpeed = (bottomScreen.GetWidth() / 20.0);
-    auto heightSpeed = (bottomScreen.GetHeight() / 20.0);
+    if (LibRetro::settings.mouse_touchscreen) {
+        // Check mouse input
+        state |= LibRetro::CheckInput(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
+        
+        // Read in and convert pointer values to absolute values on the canvas
+        auto pointerX = LibRetro::CheckInput(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
+        auto pointerY = LibRetro::CheckInput(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
+        auto newX = static_cast<int>((pointerX + 0x7fff) / (float)(0x7fff * 2) * bufferWidth);
+        auto newY = static_cast<int>((pointerY + 0x7fff) / (float)(0x7fff * 2) * bufferHeight);
 
-    // Read in and convert pointer values to absolute values on the canvas
-    auto pointerX = LibRetro::CheckInput(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
-    auto pointerY = LibRetro::CheckInput(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
-    auto newX = static_cast<int>((pointerX + 0x7fff) / (float)(0x7fff * 2) * bufferWidth);
-    auto newY = static_cast<int>((pointerY + 0x7fff) / (float)(0x7fff * 2) * bufferHeight);
-
-    if ((pointerX != 0 || pointerY != 0) && (newX != lastMouseX || newY != lastMouseY)) {
         // Use mouse pointer movement
-        lastMouseX = newX;
-        lastMouseY = newY;
+        if ((pointerX != 0 || pointerY != 0) && (newX != lastMouseX || newY != lastMouseY)) {
+            lastMouseX = newX;
+            lastMouseY = newY;
 
-        x = std::max(static_cast<int>(bottomScreen.left),
-                     std::min(newX, static_cast<int>(bottomScreen.right))) -
-            bottomScreen.left;
-        y = std::max(static_cast<int>(bottomScreen.top),
-                     std::min(newY, static_cast<int>(bottomScreen.bottom))) -
-            bottomScreen.top;
+            x = std::max(static_cast<int>(bottomScreen.left),
+                         std::min(newX, static_cast<int>(bottomScreen.right))) -
+                bottomScreen.left;
+            y = std::max(static_cast<int>(bottomScreen.top),
+                         std::min(newY, static_cast<int>(bottomScreen.bottom))) -
+                bottomScreen.top;
+        }
     } else if (LibRetro::settings.analog_function != LibRetro::CStickFunction::CStick) {
+        // Check right analog input
+        state |= LibRetro::CheckInput(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
+        
+        // TODO: Provide config option for ratios here
+        auto widthSpeed = (bottomScreen.GetWidth() / 20.0);
+        auto heightSpeed = (bottomScreen.GetHeight() / 20.0);
+
         // Use controller movement
         float controllerX =
             ((float)LibRetro::CheckInput(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT,

--- a/src/citra_libretro/input/mouse_tracker.cpp
+++ b/src/citra_libretro/input/mouse_tracker.cpp
@@ -78,7 +78,7 @@ void MouseTracker::Update(int bufferWidth, int bufferHeight,
     if (LibRetro::settings.mouse_touchscreen) {
         // Check mouse input
         state |= LibRetro::CheckInput(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
-        
+
         // Read in and convert pointer values to absolute values on the canvas
         auto pointerX = LibRetro::CheckInput(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
         auto pointerY = LibRetro::CheckInput(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
@@ -100,7 +100,7 @@ void MouseTracker::Update(int bufferWidth, int bufferHeight,
     } else if (LibRetro::settings.analog_function != LibRetro::CStickFunction::CStick) {
         // Check right analog input
         state |= LibRetro::CheckInput(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
-        
+
         // TODO: Provide config option for ratios here
         auto widthSpeed = (bottomScreen.GetWidth() / 20.0);
         auto heightSpeed = (bottomScreen.GetHeight() / 20.0);


### PR DESCRIPTION
I have my controller set to use the right joystick to move the mouse. Unfortunately there is currently no way to disable mouse input from affecting the touch screen in the Citra core, and having it receive input from the both the right analog and the "mouse" simultaneously causes pretty erratic results. It is possible to disable the controller from affecting the touch screen (setting right analog function to c-stick) and only use mouse input, but mouse input is currently broken (https://github.com/libretro/citra/issues/23) and fixing that seems more difficult.

It's a fairly simple PR so hopefully it works as expected, but I haven't tested since I'm not sure how to compile the Citra core. Are there instructions anywhere? I followed the instructions [here](https://github.com/citra-emu/citra/wiki/Building-For-Windows#mingw-w64-build-with-msys2) (just replacing the default citra repo with the libretro one) and managed to build citra.exe, but not the *.dll file that is the libretro core.