### PR TITLE
Clean frame when changing screen layout to top/bottom or large/small

### DIFF
--- a/src/citra_libretro/emu_window/libretro_window.cpp
+++ b/src/citra_libretro/emu_window/libretro_window.cpp
@@ -163,6 +163,8 @@ void EmuWindow_LibRetro::UpdateLayout() {
             baseX *= scaling;
             baseY *= scaling;
         }
+
+        doCleanFrame = true;
         break;
     case Settings::LayoutOption::SideScreen:
         baseX = Core::kScreenBottomWidth + Core::kScreenTopWidth;
@@ -180,6 +182,7 @@ void EmuWindow_LibRetro::UpdateLayout() {
         baseY = Core::kScreenTopHeight + Core::kScreenBottomHeight;
         baseX *= scaling;
         baseY *= scaling;
+        doCleanFrame = true;
         break;
     }
 


### PR DESCRIPTION
These layouts have empty areas which will contain leftover pixels otherwise.