### PR TITLE
Build fixes

### DIFF
--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <type_traits>
 #include <vector>
 #include "common/common_types.h"


### PR DESCRIPTION
The first commit fixes this:
```
In file included from /run/build/libretro-citra/src/./audio_core/dsp_interface.h:12,
                 from /run/build/libretro-citra/src/./audio_core/hle/hle.h:11,
                 from /run/build/libretro-citra/src/audio_core/hle/hle.cpp:7:
/run/build/libretro-citra/src/./common/ring_buffer.h:29:35: error: ‘numeric_limits’ is not a member of ‘std’
   29 |     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
      |                                   ^~~~~~~~~~~~~~
/run/build/libretro-citra/src/./common/ring_buffer.h:29:61: error: expected primary-expression before ‘>’ token
   29 |     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
      |                                                             ^
/run/build/libretro-citra/src/./common/ring_buffer.h:29:64: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   29 |     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
      |                                                                ^~~
      |                                                                std::max
In file included from /usr/include/c++/11.1.0/algorithm:62,
                 from /run/build/libretro-citra/src/./audio_core/hle/common.h:7,
                 from /run/build/libretro-citra/src/audio_core/hle/hle.cpp:6:
/usr/include/c++/11.1.0/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
make[3]: *** [src/audio_core/CMakeFiles/audio_core.dir/build.make:118: src/audio_core/CMakeFiles/audio_core.dir/hle/hle.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from /run/build/libretro-citra/src/./audio_core/dsp_interface.h:12,
                 from /run/build/libretro-citra/src/audio_core/dsp_interface.cpp:6:
/run/build/libretro-citra/src/./common/ring_buffer.h:29:35: error: ‘numeric_limits’ is not a member of ‘std’
   29 |     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
      |                                   ^~~~~~~~~~~~~~
/run/build/libretro-citra/src/./common/ring_buffer.h:29:61: error: expected primary-expression before ‘>’ token
   29 |     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
      |                                                             ^
/run/build/libretro-citra/src/./common/ring_buffer.h:29:64: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   29 |     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
      |                                                                ^~~
      |                                                                std::max
In file included from /usr/include/c++/11.1.0/algorithm:62,
                 from /run/build/libretro-citra/src/./common/ring_buffer.h:7,
                 from /run/build/libretro-citra/src/./audio_core/dsp_interface.h:12,
                 from /run/build/libretro-citra/src/audio_core/dsp_interface.cpp:6:
/usr/include/c++/11.1.0/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
make[3]: *** [src/audio_core/CMakeFiles/audio_core.dir/build.make:90: src/audio_core/CMakeFiles/audio_core.dir/dsp_interface.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:734: src/audio_core/CMakeFiles/audio_core.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:871: src/citra_libretro/CMakeFiles/citra_libretro.dir/rule] Error 2
make: *** [Makefile:361: citra_libretro] Error 2
Error: module libretro-citra: Le processus fils s’est terminé avec le code 2
```

The second commit fixes this:
```
In file included from /usr/include/unistd.h:226,
                 from /run/build/libretro-citra/externals/./microprofile/microprofile.h:210,
                 from /run/build/libretro-citra/src/./common/microprofile.h:23,
                 from /run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:7:
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp: In function ‘ResultCode Service::GSP::SetBufferSwap(u32, const Service::GSP::FrameBufferInfo&)’:
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:264:68: error: ‘screen_id’ is not a constant expression
  264 |                                                 framebuffer_config[screen_id].address_left1)),
      |                                                                    ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:263:62: note: in expansion of macro ‘GPU_REG_INDEX’
  263 |         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
      |                                                              ^~~~~~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:267:68: error: ‘screen_id’ is not a constant expression
  267 |                                                 framebuffer_config[screen_id].address_right1)),
      |                                                                    ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:266:62: note: in expansion of macro ‘GPU_REG_INDEX’
  266 |         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
      |                                                              ^~~~~~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:271:68: error: ‘screen_id’ is not a constant expression
  271 |                                                 framebuffer_config[screen_id].address_left2)),
      |                                                                    ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:270:62: note: in expansion of macro ‘GPU_REG_INDEX’
  270 |         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
      |                                                              ^~~~~~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:274:68: error: ‘screen_id’ is not a constant expression
  274 |                                                 framebuffer_config[screen_id].address_right2)),
      |                                                                    ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:273:62: note: in expansion of macro ‘GPU_REG_INDEX’
  273 |         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
      |                                                              ^~~~~~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:278:80: error: ‘screen_id’ is not a constant expression
  278 |                          4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].stride)),
      |                                                                                ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:278:47: note: in expansion of macro ‘GPU_REG_INDEX’
  278 |                          4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].stride)),
      |                                               ^~~~~~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:281:64: error: ‘screen_id’ is not a constant expression
  281 |                                             framebuffer_config[screen_id].color_format)),
      |                                                                ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:280:58: note: in expansion of macro ‘GPU_REG_INDEX’
  280 |     WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
      |                                                          ^~~~~~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:284:78: error: ‘screen_id’ is not a constant expression
  284 |         base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].active_fb)),
      |                                                                              ^~~~~~~~~
/run/build/libretro-citra/src/core/hle/service/gsp/gsp_gpu.cpp:284:45: note: in expansion of macro ‘GPU_REG_INDEX’
  284 |         base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].active_fb)),
      |                                             ^~~~~~~~~~~~~
make[3]: *** [src/core/CMakeFiles/core.dir/build.make:1714: src/core/CMakeFiles/core.dir/hle/service/gsp/gsp_gpu.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/Makefile2:675: src/core/CMakeFiles/core.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:871: src/citra_libretro/CMakeFiles/citra_libretro.dir/rule] Error 2
make: *** [Makefile:361: citra_libretro] Error 2
Error: module libretro-citra: Le processus fils s’est terminé avec le code 2
```