### PR TITLE
Enable remapping for Circle Pad and C-Stick + only show "Nintendo 3DS" as device type

### DIFF
--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -135,7 +135,7 @@ void LibRetro::OnConfigureEnvironment() {
     LibRetro::SetVariables(values);
 
     static const struct retro_controller_description controllers[] = {
-        {"Nintendo 3DS", RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 0)},
+        {"Nintendo 3DS", RETRO_DEVICE_JOYPAD},
     };
 
     static const struct retro_controller_info ports[] = {
@@ -171,6 +171,10 @@ void UpdateSettings() {
         {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select"},
         {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Home"},
         {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "Touch Screen Touch"},
+        {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Circle Pad X"},
+        {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Circle Pad Y"},
+        {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "C-Stick / Pointer X"},
+        {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "C-Stick / Pointer Y"},
         {0, 0},
     };
 


### PR DESCRIPTION
At the moment it's not possible to remap Circle Pad and C-Stick/Pointer from `Quick Menu > Controls`, they're not listed in the available buttons and it only shows `---` by default:

![image](https://user-images.githubusercontent.com/33353403/138075389-711ce342-e5af-4a1c-ac0c-3c3654f0c9eb.png)

This PR changes that:

![image](https://user-images.githubusercontent.com/33353403/138073845-26b930ba-c20c-43de-a6ad-6fbf69b22159.png)

Also removed the subclass for controls since there's only 1 device type, seems just confusing for the user to have both "RetroPad" and "Nintendo 3DS" listed as device types:

![image](https://user-images.githubusercontent.com/33353403/138074136-67a1b810-d32d-49bb-ac8e-81219d1adc65.png)

So now with this PR it only lists "Nintendo 3DS":

![image](https://user-images.githubusercontent.com/33353403/138074197-d86a8da8-cbf5-49a0-9f71-935c4e15fdc8.png)

**edit:** Updated for the rebase.