### PR TITLE
Add language core option

### DIFF
--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -129,6 +129,8 @@ void LibRetro::OnConfigureEnvironment() {
         {"citra_is_new_3ds", "3DS system model; Old 3DS|New 3DS"},
         {"citra_region_value",
          "3DS system region; Auto|Japan|USA|Europe|Australia|China|Korea|Taiwan"},
+        {"citra_language", "3DS system language; English|Japanese|French|Spanish|German|Italian|Dutch|Portuguese|"
+                           "Russian|Korean|Traditional Chinese|Simplified Chinese"},
         {"citra_use_gdbstub", "Enable GDB stub; disabled|enabled"},
         {nullptr, nullptr}};
 
@@ -285,6 +287,36 @@ void UpdateSettings() {
         Settings::values.region_value = -1;
     } else {
         Settings::values.region_value = result->second;
+    }
+
+    auto language = LibRetro::FetchVariable("citra_language", "English");
+    if (language == "English") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_EN;
+    } else if (language == "Japanese") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_JP;
+    } else if (language == "French") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_FR;
+    } else if (language == "Spanish") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_ES;
+    } else if (language == "German") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_DE;
+    } else if (language == "Italian") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_IT;
+    } else if (language == "Dutch") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_NL;
+    } else if (language == "Portuguese") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_PT;
+    } else if (language == "Russian") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_RU;
+    } else if (language == "Korean") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_KO;
+    } else if (language == "Traditional Chinese") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_TW;
+    } else if (language == "Simplified Chinese") {
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_ZH;
+    } else {
+        LOG_ERROR(Frontend, "Invalid language: {}.", language);
+        LibRetro::settings.language_value = Service::CFG::LANGUAGE_EN;
     }
 
     Settings::values.current_input_profile.touch_device = "engine:emu_window";

--- a/src/citra_libretro/core_settings.h
+++ b/src/citra_libretro/core_settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include "core/hle/service/cfg/cfg.h"
 
 namespace LibRetro {
 
@@ -19,6 +20,8 @@ struct CoreSettings {
     LibRetro::CStickFunction analog_function;
 
     bool mouse_touchscreen;
+
+    Service::CFG::SystemLanguage language_value;
 
 } extern settings;
 

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -27,6 +27,7 @@
 #include "core/hle/service/cfg/cfg_s.h"
 #include "core/hle/service/cfg/cfg_u.h"
 #include "core/settings.h"
+#include "citra_libretro/core_settings.h"
 
 SERIALIZE_EXPORT_IMPL(Service::CFG::Module)
 
@@ -649,6 +650,9 @@ static std::tuple<u32 /*region*/, SystemLanguage> AdjustLanguageInfoBlock(
 }
 
 void Module::SetPreferredRegionCodes(const std::vector<u32>& region_codes) {
+    // Apply language set in core options first
+    SetSystemLanguage(LibRetro::settings.language_value);
+
     const SystemLanguage current_language = GetSystemLanguage();
     auto [region, adjusted_language] = AdjustLanguageInfoBlock(region_codes, current_language);
 


### PR DESCRIPTION
This PR adds a "3DS system language" core option, this is a long requested feature because some multi-languages games don't have an in-game option to change the language and uses the 3DS setting instead. Before this PR you had to use standalone to change and then transfer the "config" file to the correct RetroArch Citra save folder in order to switch... not ideal to say the least.

Of course the setting can be ignored depending on the game, not all games support every languages.

Here's a quick showcase with the EU version of Zelda OoT, which includes EN/FR/ES/DE/IT languages but no in-game option to switch, you can see the "PRESS START" displaying in the new language after the restart:

https://user-images.githubusercontent.com/33353403/147573121-66d95739-c81d-46b7-846d-b41bdf34a8e7.mp4

Not sure if there's a better way to handle that, but it worked fine on the ~10 games I tried, tested on Windows 10 and a Linux Mint VM.

**edit:** Updated for the rebase.