### PR TITLE
Avoid caching framebuffer in core

### DIFF
--- a/src/citra_libretro/emu_window/libretro_window.cpp
+++ b/src/citra_libretro/emu_window/libretro_window.cpp
@@ -76,7 +76,7 @@ void EmuWindow_LibRetro::SwapBuffers() {
 
 void EmuWindow_LibRetro::SetupFramebuffer() {
     // TODO: Expose interface in renderer_opengl to configure this in it's internal state
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, framebuffer);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(LibRetro::GetFramebuffer()));
 
     // glClear can be a slow path - skip clearing if we don't need to.
     if (doCleanFrame) {
@@ -228,8 +228,6 @@ bool EmuWindow_LibRetro::HasSubmittedFrame() {
 }
 
 void EmuWindow_LibRetro::CreateContext() {
-    framebuffer = static_cast<GLuint>(LibRetro::GetFramebuffer());
-
     if (enableEmulatedPointer) {
         tracker = std::make_unique<LibRetro::Input::MouseTracker>();
     }

--- a/src/citra_libretro/emu_window/libretro_window.h
+++ b/src/citra_libretro/emu_window/libretro_window.h
@@ -67,8 +67,6 @@ private:
     // For tracking LibRetro state
     bool hasTouched = false;
 
-    GLuint framebuffer;
-
     // For tracking mouse cursor
     std::unique_ptr<LibRetro::Input::MouseTracker> tracker = nullptr;
 


### PR DESCRIPTION
Frontend should be able to change at any time such as when switching resolutions or creating effects which rely on previous frames.