### PR TITLE
Use top screen width as "baseX" even if screens are swapped

### DIFF
--- a/src/citra_libretro/emu_window/libretro_window.cpp
+++ b/src/citra_libretro/emu_window/libretro_window.cpp
@@ -173,11 +173,7 @@ void EmuWindow_LibRetro::UpdateLayout() {
         break;
     case Settings::LayoutOption::Default:
     default:
-        if (swapped) { // Bottom screen on top
-            baseX = Core::kScreenBottomWidth;
-        } else { // Top screen on top
-            baseX = Core::kScreenTopWidth;
-        }
+        baseX = Core::kScreenTopWidth;
         baseY = Core::kScreenTopHeight + Core::kScreenBottomHeight;
         baseX *= scaling;
         baseY *= scaling;


### PR DESCRIPTION
Currently when swapping screens (either from the "Prominent 3DS screen" core option or with L3) the width is set to the bottom screen width so the surface becomes much smaller, here's an example:

Normal:

![image](https://user-images.githubusercontent.com/33353403/219347483-69c9dab4-c2e4-43c8-9fac-77baa20d1a6c.png)

Swapped:

![image](https://user-images.githubusercontent.com/33353403/219347518-d98438ec-eac3-4303-9b7e-299baaf06f12.png)

So just by swapping screens I lost all of that red area:

![image](https://user-images.githubusercontent.com/33353403/219361516-0b0a1165-7067-4f1f-9fee-fd6a8111b172.png)

With this little PR it will use the top screen width, no matter if screens are swapped or not:

![image](https://user-images.githubusercontent.com/33353403/219360660-533b097b-f0cc-4fef-bafb-8d912b159f4a.png)

