### PR TITLE
Replace removed submodules from citra-emu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,13 +6,13 @@
 	url = https://github.com/libretro-fork/nihstro.git
 [submodule "soundtouch"]
     path = externals/soundtouch
-    url = https://github.com/citra-emu/ext-soundtouch.git
+    url = https://github.com/rtiangha/ext-soundtouch.git
 [submodule "catch"]
     path = externals/catch
     url = https://github.com/philsquared/Catch.git
 [submodule "dynarmic"]
     path = externals/dynarmic
-    url = https://github.com/citra-emu/dynarmic.git
+    url = https://github.com/rtiangha/dynarmic-old.git
 [submodule "xbyak"]
     path = externals/xbyak
     url = https://github.com/herumi/xbyak.git
@@ -30,7 +30,7 @@
     url = https://github.com/benhoyt/inih.git
 [submodule "libressl"]
     path = externals/libressl
-    url = https://github.com/citra-emu/ext-libressl-portable.git
+    url = https://github.com/PabloMK7/ext-libressl-portable.git
 [submodule "libusb"]
     path = externals/libusb/libusb
     url = https://github.com/libusb/libusb.git


### PR DESCRIPTION
This replaces the deleted citra-emu organization repositories with forks/clones that exist.