### PR TITLE
change android target name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ android-arm64-v8a:
     - .libretro-android-cmake-arm64-v8a
     - .core-defs
   variables:
-    LIBNAME: ${CORENAME}_libretro.so
+    LIBNAME: ${CORENAME}_libretro_android.so
   before_script:
     - export NUMPROC=$(($(nproc)/5))
     - perl -pi -e 's/bullseye/bookworm/g' /etc/apt/sources.list


### PR DESCRIPTION
this was causing the updated core to be named citra_libretro.so instead of citra_libretro_android.so like all of the other android libs, and this caused 2 copies of the lib to be recognized in the online updater with no way to distinguish between them since they both get matched against the same info file. We'll need to delete citra_libretro.so from the webserver once this is done.