### PR TITLE
delete 'variables' from android section

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,8 +75,6 @@ android-arm64-v8a:
   extends:
     - .libretro-android-cmake-arm64-v8a
     - .core-defs
-  variables:
-    LIBNAME: ${CORENAME}_libretro.so
   before_script:
     - export NUMPROC=$(($(nproc)/5))
     - perl -pi -e 's/bullseye/bookworm/g' /etc/apt/sources.list


### PR DESCRIPTION
this was overriding the base recipe, which cause the lib output to be named citra_libretro.so instead of citra_libretro_android.so.