### PR TITLE
Compilation fixes/improvements for core and webOS support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,12 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/libnx-static.yml'
 
+  #################################### MISC ##################################
+
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-cmake.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -76,3 +82,12 @@ android-arm64-v8a:
 #   extends:
 #     - .core-defs
 #     - .libretro-libnx-static-retroarch-master
+
+#################################### MISC ##################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-cmake
+    - .core-defs
+  variables:
+    CORE_ARGS: "${BASE_CORE_ARGS} -DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,18 @@ if(ENABLE_LIBRETRO)
     set(CITRA_ENABLE_BUNDLE_TARGET OFF)
 endif()
 
+if(CMAKE_CXX_COMPILER MATCHES "webos" OR
+    CMAKE_CXX_COMPILER MATCHES "starfish")
+    set(WEBOS ON)
+    add_definitions(-DWEBOS=1)
+endif()
+
+if(WEBOS)
+    set(ENABLE_VULKAN OFF)
+     # temp fix for fmt/ranges.h:211:59: error: self-comparison always evaluates to true [-Werror=tautological-compare]
+    add_definitions(-Wno-tautological-compare)
+endif()
+
 include(CitraHandleSystemLibs)
 
 if (CITRA_USE_PRECOMPILED_HEADERS)
@@ -340,6 +352,7 @@ if (ENABLE_QT)
 endif()
 
 # Use system tsl::robin_map if available (otherwise we fallback to version bundled with dynarmic)
+set(TSL_ROBIN_MAP_ENABLE_INSTALL ON CACHE BOOL "" FORCE)
 find_package(tsl-robin-map QUIET)
 
 if (NOT TARGET tsl::robin_map)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ else()
     set(IS_RELEASE_BUILD ON)
 endif()
 
+option(ENABLE_VULKAN "Enable Vulkan Video Core" ON)
+
 # LTO takes too much memory and time using MSVC.
 if (NOT MSVC AND NOT MINGW AND IS_RELEASE_BUILD)
     set(DEFAULT_ENABLE_LTO ON)
@@ -91,6 +93,20 @@ CMAKE_DEPENDENT_OPTION(COMPILE_WITH_DWARF "Add DWARF debugging information" ${IS
 option(ENABLE_LTO "Enable link time optimization" ${DEFAULT_ENABLE_LTO})
 option(CITRA_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(CITRA_WARNINGS_AS_ERRORS "Enable warnings as errors" ON)
+
+# Disable features not used by a libretro core
+# =======================================================================
+if(ENABLE_LIBRETRO)
+    set(ENABLE_QT OFF)
+    set(ENABLE_QT_UPDATER OFF)
+    set(ENABLE_DEDICATED_ROOM OFF)
+    set(ENABLE_WEB_SERVICE OFF)
+    set(ENABLE_SCRIPTING OFF)
+    set(ENABLE_CUBEB OFF)
+    set(ENABLE_OPENAL OFF)
+    set(ENABLE_TESTS OFF)
+    set(CITRA_ENABLE_BUNDLE_TARGET OFF)
+endif()
 
 include(CitraHandleSystemLibs)
 
@@ -325,6 +341,14 @@ endif()
 
 # Use system tsl::robin_map if available (otherwise we fallback to version bundled with dynarmic)
 find_package(tsl-robin-map QUIET)
+
+if (NOT TARGET tsl::robin_map)
+    if (EXISTS "${CMAKE_SOURCE_DIR}/externals/dynarmic/externals/robin-map/CMakeLists.txt")
+        add_subdirectory(externals/dynarmic/externals/robin-map)
+    else()
+        message(FATAL_ERROR "tsl-robin-map not found: please install it or initialize submodules")
+    endif()
+endif()
 
 # Platform-specific library requirements
 # ======================================

--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -8,14 +8,19 @@ add_library(citra_libretro SHARED
         input/input_factory.h
         input/mouse_tracker.cpp
         input/mouse_tracker.h
-        vulkan/vk_swapchain.cpp
-        vulkan/vk_swapchain.h
         citra_libretro.cpp
         citra_libretro.h
         environment.cpp
         environment.h
         core_settings.cpp
         core_settings.h)
+
+if(ENABLE_VULKAN)
+  add_library(citra_libretro SHARED
+    vulkan/vk_swapchain.cpp
+    vulkan/vk_swapchain.h
+  )
+endif()
 
 create_target_directory_groups(citra_libretro)
 

--- a/src/common/atomic_ops.h
+++ b/src/common/atomic_ops.h
@@ -11,6 +11,11 @@
 #include <cstring>
 #endif
 
+#if !defined(__SIZEOF_INT128__)
+#include <mutex>
+inline std::mutex g_atomic128_mutex;
+#endif
+
 namespace Common {
 
 #if _MSC_VER
@@ -107,14 +112,6 @@ namespace Common {
     return __sync_bool_compare_and_swap(pointer, expected, value);
 }
 
-[[nodiscard]] inline bool AtomicCompareAndSwap(volatile u64* pointer, u128 value, u128 expected) {
-    unsigned __int128 value_a;
-    unsigned __int128 expected_a;
-    std::memcpy(&value_a, value.data(), sizeof(u128));
-    std::memcpy(&expected_a, expected.data(), sizeof(u128));
-    return __sync_bool_compare_and_swap((unsigned __int128*)pointer, expected_a, value_a);
-}
-
 [[nodiscard]] inline bool AtomicCompareAndSwap(volatile u8* pointer, u8 value, u8 expected,
                                                u8& actual) {
     actual = __sync_val_compare_and_swap(pointer, expected, value);
@@ -139,8 +136,94 @@ namespace Common {
     return actual == expected;
 }
 
+#if !defined(__SIZEOF_INT128__)
+
+[[nodiscard]] inline bool AtomicCompareAndSwap(volatile u64* pointer, u128 value, u128 expected)
+{
+    std::lock_guard<std::mutex> lock(g_atomic128_mutex);
+
+    auto ptr64 = reinterpret_cast<volatile u64*>(pointer);
+
+    u64 cur_lo = ptr64[0];
+    u64 cur_hi = ptr64[1];
+
+    u64 exp_lo, exp_hi;
+    std::memcpy(&exp_lo, expected.data() + 0, sizeof(u64));
+    std::memcpy(&exp_hi, expected.data() + 1, sizeof(u64));
+
+    if (cur_lo == exp_lo && cur_hi == exp_hi) {
+        u64 val_lo, val_hi;
+        std::memcpy(&val_lo, value.data() + 0, sizeof(u64));
+        std::memcpy(&val_hi, value.data() + 1, sizeof(u64));
+
+        ptr64[0] = val_lo;
+        ptr64[1] = val_hi;
+        return true;
+    }
+
+    return false;
+}
+
+[[nodiscard]] inline bool AtomicCompareAndSwap(volatile u64* pointer, u128 value, u128 expected, u128& actual)
+{
+    std::lock_guard<std::mutex> lock(g_atomic128_mutex);
+
+    auto ptr64 = reinterpret_cast<volatile u64*>(pointer);
+
+    u64 cur_lo = ptr64[0];
+    u64 cur_hi = ptr64[1];
+
+    // write back actual
+    std::memcpy(actual.data() + 0, &cur_lo, sizeof(u64));
+    std::memcpy(actual.data() + 1, &cur_hi, sizeof(u64));
+
+    u64 exp_lo, exp_hi;
+    std::memcpy(&exp_lo, expected.data() + 0, sizeof(u64));
+    std::memcpy(&exp_hi, expected.data() + 1, sizeof(u64));
+
+    if (cur_lo == exp_lo && cur_hi == exp_hi) {
+        u64 val_lo, val_hi;
+        std::memcpy(&val_lo, value.data() + 0, sizeof(u64));
+        std::memcpy(&val_hi, value.data() + 1, sizeof(u64));
+
+        ptr64[0] = val_lo;
+        ptr64[1] = val_hi;
+        return true;
+    }
+
+    return false;
+}
+
+[[nodiscard]] inline u128 AtomicLoad128(volatile u64* pointer)
+{
+    std::lock_guard<std::mutex> lock(g_atomic128_mutex);
+
+    auto ptr64 = reinterpret_cast<volatile u64*>(pointer);
+
+    u128 result;
+    u64 lo = ptr64[0];
+    u64 hi = ptr64[1];
+
+    std::memcpy(result.data() + 0, &lo, sizeof(u64));
+    std::memcpy(result.data() + 1, &hi, sizeof(u64));
+
+    return result;
+}
+
+#else
+
+[[nodiscard]] inline bool AtomicCompareAndSwap(volatile u64* pointer, u128 value, u128 expected)
+{
+    unsigned __int128 value_a;
+    unsigned __int128 expected_a;
+    std::memcpy(&value_a, value.data(), sizeof(u128));
+    std::memcpy(&expected_a, expected.data(), sizeof(u128));
+    return __sync_bool_compare_and_swap((unsigned __int128*)pointer, expected_a, value_a);
+}
+
 [[nodiscard]] inline bool AtomicCompareAndSwap(volatile u64* pointer, u128 value, u128 expected,
-                                               u128& actual) {
+                                               u128& actual)
+{
     unsigned __int128 value_a;
     unsigned __int128 expected_a;
     unsigned __int128 actual_a;
@@ -151,7 +234,8 @@ namespace Common {
     return actual_a == expected_a;
 }
 
-[[nodiscard]] inline u128 AtomicLoad128(volatile u64* pointer) {
+[[nodiscard]] inline u128 AtomicLoad128(volatile u64* pointer)
+{
     unsigned __int128 zeros_a = 0;
     unsigned __int128 result_a =
         __sync_val_compare_and_swap((unsigned __int128*)pointer, zeros_a, zeros_a);
@@ -161,6 +245,7 @@ namespace Common {
     return result;
 }
 
-#endif
+#endif // __SIZEOF_INT128__
+#endif // _MSC_VER
 
 } // namespace Common

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -395,7 +395,7 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
 #else
         for (u32 i = 0; i < num_cores; ++i) {
             cpu_cores.push_back(
-                std::make_shared<ARM_DynCom>(this, *memory, USER32MODE, i, timing->GetTimer(i)));
+                std::make_shared<ARM_DynCom>(*this, *memory, USER32MODE, i, timing->GetTimer(i)));
         }
         LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -42,7 +42,7 @@ public:
         if (offset > size) {
             return ERR_WRITE_BEYOND_END;
         } else if (offset == size) {
-            return 0ULL;
+            return static_cast<std::size_t>(0);
         }
 
         if (offset + length > size) {

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -258,7 +258,7 @@ ResultVal<std::size_t> NCCHFile::Write(const u64 offset, const std::size_t lengt
                                        const u8* buffer) {
     LOG_ERROR(Service_FS, "Attempted to write to NCCH file");
     // TODO(shinyquagsire23): Find error code
-    return 0ULL;
+    return static_cast<std::size_t>(0);
 }
 
 u64 NCCHFile::GetSize() const {

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -105,7 +105,7 @@ ResultVal<std::size_t> IVFCFile::Write(const u64 offset, const std::size_t lengt
                                        const u8* buffer) {
     LOG_ERROR(Service_FS, "Attempted to write to IVFC file");
     // TODO(Subv): Find error code
-    return 0ULL;
+    return static_cast<std::size_t>(0);
 }
 
 u64 IVFCFile::GetSize() const {
@@ -136,7 +136,7 @@ ResultVal<std::size_t> IVFCFileInMemory::Write(const u64 offset, const std::size
                                                const bool flush, const u8* buffer) {
     LOG_ERROR(Service_FS, "Attempted to write to IVFC file");
     // TODO(Subv): Find error code
-    return 0ULL;
+    return static_cast<std::size_t>(0);
 }
 
 u64 IVFCFileInMemory::GetSize() const {

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -96,46 +96,6 @@ add_library(video_core STATIC
     renderer_software/sw_rasterizer.h
     renderer_software/sw_texturing.cpp
     renderer_software/sw_texturing.h
-    renderer_vulkan/pica_to_vk.h
-    renderer_vulkan/renderer_vulkan.cpp
-    renderer_vulkan/renderer_vulkan.h
-    renderer_vulkan/vk_blit_helper.cpp
-    renderer_vulkan/vk_blit_helper.h
-    renderer_vulkan/vk_common.cpp
-    renderer_vulkan/vk_common.h
-    renderer_vulkan/vk_descriptor_pool.cpp
-    renderer_vulkan/vk_descriptor_pool.h
-    renderer_vulkan/vk_graphics_pipeline.cpp
-    renderer_vulkan/vk_graphics_pipeline.h
-    renderer_vulkan/vk_master_semaphore.cpp
-    renderer_vulkan/vk_master_semaphore.h
-    renderer_vulkan/vk_memory_util.cpp
-    renderer_vulkan/vk_memory_util.h
-    renderer_vulkan/vk_rasterizer.cpp
-    renderer_vulkan/vk_rasterizer.h
-    renderer_vulkan/vk_rasterizer_cache.cpp
-    renderer_vulkan/vk_scheduler.cpp
-    renderer_vulkan/vk_scheduler.h
-    renderer_vulkan/vk_resource_pool.cpp
-    renderer_vulkan/vk_resource_pool.h
-    renderer_vulkan/vk_instance.cpp
-    renderer_vulkan/vk_instance.h
-    renderer_vulkan/vk_pipeline_cache.cpp
-    renderer_vulkan/vk_pipeline_cache.h
-    renderer_vulkan/vk_platform.cpp
-    renderer_vulkan/vk_platform.h
-    renderer_vulkan/vk_present_window.cpp
-    renderer_vulkan/vk_present_window.h
-    renderer_vulkan/vk_renderpass_cache.cpp
-    renderer_vulkan/vk_renderpass_cache.h
-    renderer_vulkan/vk_shader_util.cpp
-    renderer_vulkan/vk_shader_util.h
-    renderer_vulkan/vk_stream_buffer.cpp
-    renderer_vulkan/vk_stream_buffer.h
-    renderer_vulkan/vk_swapchain.cpp
-    renderer_vulkan/vk_swapchain.h
-    renderer_vulkan/vk_texture_runtime.cpp
-    renderer_vulkan/vk_texture_runtime.h
     shader/debug_data.h
     shader/generator/glsl_fs_shader_gen.cpp
     shader/generator/glsl_fs_shader_gen.h
@@ -172,6 +132,51 @@ add_library(video_core STATIC
     video_core.cpp
     video_core.h
 )
+
+if(ENABLE_VULKAN)
+    add_library(video_core STATIC
+        renderer_vulkan/pica_to_vk.h
+        renderer_vulkan/renderer_vulkan.cpp
+        renderer_vulkan/renderer_vulkan.h
+        renderer_vulkan/vk_blit_helper.cpp
+        renderer_vulkan/vk_blit_helper.h
+        renderer_vulkan/vk_common.cpp
+        renderer_vulkan/vk_common.h
+        renderer_vulkan/vk_descriptor_pool.cpp
+        renderer_vulkan/vk_descriptor_pool.h
+        renderer_vulkan/vk_graphics_pipeline.cpp
+        renderer_vulkan/vk_graphics_pipeline.h
+        renderer_vulkan/vk_master_semaphore.cpp
+        renderer_vulkan/vk_master_semaphore.h
+        renderer_vulkan/vk_memory_util.cpp
+        renderer_vulkan/vk_memory_util.h
+        renderer_vulkan/vk_rasterizer.cpp
+        renderer_vulkan/vk_rasterizer.h
+        renderer_vulkan/vk_rasterizer_cache.cpp
+        renderer_vulkan/vk_scheduler.cpp
+        renderer_vulkan/vk_scheduler.h
+        renderer_vulkan/vk_resource_pool.cpp
+        renderer_vulkan/vk_resource_pool.h
+        renderer_vulkan/vk_instance.cpp
+        renderer_vulkan/vk_instance.h
+        renderer_vulkan/vk_pipeline_cache.cpp
+        renderer_vulkan/vk_pipeline_cache.h
+        renderer_vulkan/vk_platform.cpp
+        renderer_vulkan/vk_platform.h
+        renderer_vulkan/vk_present_window.cpp
+        renderer_vulkan/vk_present_window.h
+        renderer_vulkan/vk_renderpass_cache.cpp
+        renderer_vulkan/vk_renderpass_cache.h
+        renderer_vulkan/vk_shader_util.cpp
+        renderer_vulkan/vk_shader_util.h
+        renderer_vulkan/vk_stream_buffer.cpp
+        renderer_vulkan/vk_stream_buffer.h
+        renderer_vulkan/vk_swapchain.cpp
+        renderer_vulkan/vk_swapchain.h
+        renderer_vulkan/vk_texture_runtime.cpp
+        renderer_vulkan/vk_texture_runtime.h
+    )
+endif()
 
 add_dependencies(video_core host_shaders)
 target_include_directories(video_core PRIVATE ${HOST_SHADERS_INCLUDE})


### PR DESCRIPTION
- Makes vulkan optional and enabled by default
- Disable QT etc. not needed for a libretro core
- Fixes compilation errors with modern GCC 14
- Add webOS as a platform
- Updates CI

Please test! (not the webOS bit)

I've assumed these are not needed. If I'm wrong let me know:

```
if(ENABLE_LIBRETRO)
    set(ENABLE_QT OFF)
    set(ENABLE_QT_UPDATER OFF)
    set(ENABLE_DEDICATED_ROOM OFF)
    set(ENABLE_WEB_SERVICE OFF)
    set(ENABLE_SCRIPTING OFF)
    set(ENABLE_CUBEB OFF)
    set(ENABLE_OPENAL OFF)
    set(ENABLE_TESTS OFF)
    set(CITRA_ENABLE_BUNDLE_TARGET OFF)
endif()
```