### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-cmake-aarch64.yml'
+
   ################################## CELLULAR ##############################  ##
   # Android
   - project: 'libretro-infrastructure/ci-templates'
@@ -57,6 +61,17 @@ libretro-build-linux-x64:
     - .core-defs
     - .libretro-linux-cmake-x86_64
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
+  variables:
+    CORE_ARGS: ${BASE_CORE_ARGS} -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .core-defs
+    - .libretro-linux-cmake-aarch64
+  # Same as the x64 job: the default image's GCC is too old for this core's
+  # C++ usage, so use the backports image and GCC 11.
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports
   variables:
     CORE_ARGS: ${BASE_CORE_ARGS} -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,10 +21,6 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
-  # Linux ARM 64-bit
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/linux-cmake-aarch64.yml'
-
   ################################## CELLULAR ##############################  ##
   # Android
   - project: 'libretro-infrastructure/ci-templates'
@@ -69,11 +65,11 @@ libretro-build-linux-aarch64:
   extends:
     - .core-defs
     - .libretro-linux-cmake-aarch64
-  # Same as the x64 job: the default image's GCC is too old for this core's
-  # C++ usage, so use the backports image and GCC 11.
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports
+  # No image override: unlike the x64 image, the aarch64 one already ships a
+  # modern GCC (12, from ppa:ubuntu-toolchain-r/test in its Dockerfile), and it
+  # has no :backports tag at all. GCC 11 is not packaged there, so use 12.
   variables:
-    CORE_ARGS: ${BASE_CORE_ARGS} -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+    CORE_ARGS: ${BASE_CORE_ARGS} -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
 
 ################################### CELLULAR #################################
 # Android ARMv8a


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job so the core is built for Linux aarch64 on the buildbot (currently there's no Linux aarch64 nightly for citra).

The core already compiles for aarch64 via the existing `android-arm64-v8a` job (dynarmic's AArch64 backend, the a64 shader JIT, etc.), and the CMake build detects `__aarch64__` correctly. This job simply reuses the same CMake path with GCC 11 on the aarch64 backports image, mirroring the existing `libretro-build-linux-x64` job.

**Verified on real aarch64 hardware** (Qualcomm Adreno 618, postmarketOS): built `citra_libretro.so` (ELF ARM aarch64, ~40 MB) from this branch and ran it in RetroArch -- *Asterix: The Mansions of the Gods* (3DS) boots and renders its intro via the OpenGL HW renderer (GL 4.6/freedreno, 400x480 dual-screen). The AArch64 dynarmic JIT and a64 shader JIT paths are exercised.

Note: my local build used a much newer toolchain (GCC 15) than the CI (GCC 11) and needed a one-line `#include <cstdint>` workaround in the vendored glslang for it to compile -- that's a GCC-15 quirk, not relevant to the GCC-11 buildbot, so it's intentionally not part of this PR.