### PR TITLE
ci: add the Android x86_64 and macOS arm64 builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
+  # MacOS ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-cmake-arm64.yml'
+
   ################################## CELLULAR ##############################  ##
   # Android
   - project: 'libretro-infrastructure/ci-templates'
@@ -70,6 +74,14 @@ libretro-build-linux-aarch64:
   # has no :backports tag at all. GCC 11 is not packaged there, so use 12.
   variables:
     CORE_ARGS: ${BASE_CORE_ARGS} -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
+
+# MacOS ARM 64-bit
+libretro-build-osx-arm64:
+  extends:
+    - .core-defs
+    - .libretro-osx-cmake-arm64
+  variables:
+    CORE_ARGS: ${BASE_CORE_ARGS} -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 ################################### CELLULAR #################################
 # Android ARMv8a

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,22 @@ android-arm64-v8a:
     ANDROID_NDK_VERSION: 29.0.14206865
     NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
 
+# Android 64-bit x86
+#
+# Held to NDK 26 on purpose. This is the ABI that compiles dynarmic's x64
+# backend, and the mcl headers it pulls in do not survive the clang in NDK 29:
+# "implicit instantiation of undefined template
+# mcl::mp::detail::lift_sequence_impl". arm64-v8a never reaches that code,
+# which is why it is fine on 29. 26.2 is also a version the template leaves
+# alone - it rewrites a request for 27.3 into 29.
+android-x86_64:
+  extends:
+    - .libretro-android-cmake-x86_64
+    - .core-defs
+  variables:
+    ANDROID_NDK_VERSION: 26.2.11394342
+    NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
+
 ################################### CONSOLES #################################
 
 # libretro-build-libnx-aarch64:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,9 @@ if (APPLE)
         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
         set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
     else()
-        # Minimum macOS 11
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+        # Minimum macOS 13.3: std::format's floating point path needs
+        # std::to_chars, which libc++ marks as available from there.
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "13.3")
     endif()
 endif()
 


### PR DESCRIPTION
arm64-v8a is the only Android ABI the buildbot builds, and there is no Apple job at all. This adds `android-x86_64` and `osx-arm64`; each needs one thing of its own.

### Android x86_64 — NDK 26 rather than 29

x86_64 is the ABI that compiles dynarmic's x64 backend, and the mcl headers it pulls in do not survive the clang in NDK 29:

```
externals/dynarmic/externals/mcl/include/mcl/mp/typelist/lift_sequence.hpp:27:1:
error: implicit instantiation of undefined template
'mcl::mp::detail::lift_sequence_impl<std::integer_sequence<unsigned long, 0, 1, ...>>'
```

arm64-v8a never reaches that code, which is why it is fine on 29 — so this leaves it alone rather than moving both. 26.2.11394342 is a version the android-cmake template does not rewrite (it turns a request for 27.3 into 29) and one the image already has: panda3ds pins the same one and builds with it.

Verified: the job produces `citra_libretro_android.so`, `ELF 64-bit LSB shared object, x86-64`. On NDK 29 the same build stops in dynarmic.

### macOS arm64 — needs the deployment target raised, in a commit of its own

The tree pins `CMAKE_OSX_DEPLOYMENT_TARGET "11.0"` in `CMakeLists.txt` and then uses `std::format` on floating point, which libc++ implements through `std::to_chars`, marked available from macOS 13.3. So every macOS build ends in:

```
formatter_floating_point.h:74:30: error: 'to_chars' is unavailable: introduced in macOS 13.3
```

Because the target is set in the tree, passing `MACOSX_DEPLOYMENT_TARGET` from CI does not help — I tried 13.3 that way first and it made no difference. With the line raised to 13.3, `osx-arm64` builds and produces `citra_libretro.dylib`, `architecture: arm64`.

That is a real policy change — it drops macOS 11 and 12 — so it sits in its own commit (`Raise the macOS minimum to 13.3`) and can be dropped on its own if you would rather solve it another way; the macOS job goes with it.

### Not included

- **osx-x64** links against OpenSSL through httplib and fails with `ld: symbol(s) not found for architecture x86_64` when the x86_64 slice is cross-compiled from an arm64 host.
- **iOS / tvOS** stop in configure at `find_library(MOLTENVK_LIBRARY MoltenVK REQUIRED)`: `download_moltenvk()` fetches `MoltenVK-all.tar` and looks for `MoltenVK/dylib/iOS` inside, which current MoltenVK releases no longer lay out that way. macOS finds its copy fine.